### PR TITLE
Use token from Akeyless for GitHub auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,15 +14,26 @@ jobs:
       repository-projects: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Get GitHub Token from Akeyless
+        id: get_github_token
+        uses:
+          docker://us-west1-docker.pkg.dev/devopsre/akeyless-public/akeyless-action:latest
+        with:
+          api-url: https://api.gateway.akeyless.celo-networks-dev.org
+          access-id: p-kf9vjzruht6l
+          dynamic-secrets: '{"/dynamic-secrets/keys/github/compliance/contents=write,pull_requests=write":"PAT"}'
 
-      - name: Akeyless Get Secrets
-        id: get_auth_token
+      - name: Get NPM Token from Akeyless
+        id: get_npmjs_token
         uses: docker://us-west1-docker.pkg.dev/devopsre/akeyless-public/akeyless-action:latest
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
           static-secrets: '{"/static-secrets/NPM/npm-publish-token":"NPM_TOKEN"}'
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ env.PAT }}
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Use token from akeyless instead of default GitHub $GITHUB_TOKEN.
Require https://github.com/celo-org/akeyless/pull/518