### PR TITLE
Nit: removes forgotten link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ by providing them in a JSON format via an API (recommended) or direct import (di
 
 ## Update Cadence
 
-> [!IMPORTANT] Please note that there is currently no SLA for how quickly the repository will be
+> [!IMPORTANT]
+> Please note that there is currently no SLA for how quickly the repository will be
 > updated to reflect the most recent OFAC sanctioned addresses. Updates will be done on a
 > best-effort basis.
 
@@ -38,7 +39,8 @@ export async function getSanctionedAddresses(): Promise<string[]> {
 }
 ```
 
-> [!TIP] No changes to your code will be necessary when the list is updated as this API will always
+> [!TIP]
+> No changes to your code will be necessary when the list is updated as this API will always
 > return the latest version.
 
 ### Option 2: Import the SANCTIONED_ADDRESSES list (discouraged)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @celo/compliance
+# OFAC Compliance
 
 A simple package to help you stay compliant with OFAC sanctioned addresses (e.g. front-ends, other
 applicable products).
@@ -42,8 +42,6 @@ export async function getSanctionedAddresses(): Promise<string[]> {
 > return the latest version.
 
 ### Option 2: Import the SANCTIONED_ADDRESSES list (discouraged)
-
-[import the SDK](https://www.npmjs.com/package/@celo/compliance)
 
 If you really want to, you can explicitly import the `SANCTIONED_ADDRESSES` list exported in the 
 [`@celo/compliance`](https://www.npmjs.com/package/@celo/compliance) package directly into your code.


### PR DESCRIPTION
Cleans up small typo in `README` after this PR: 
- https://github.com/celo-org/compliance/pull/17